### PR TITLE
avoid deprecated java.net.URL constructor

### DIFF
--- a/publish.sbt
+++ b/publish.sbt
@@ -14,5 +14,5 @@ ThisBuild / developers := List(
 )
 
 ThisBuild / description := "sbt plugin of Java Instant-document Gazer"
-ThisBuild / licenses    := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+ThisBuild / licenses    := List("Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / homepage    := organizationHomepage.value


### PR DESCRIPTION
- https://github.com/openjdk/jdk/commit/4338f527aa81350e3636dcfbcd2eb17ddaad3914 
- https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String) 
- https://bugs.openjdk.org/browse/JDK-8295949